### PR TITLE
feat: developまたはmainブランチへのコミットを制限する処理を追加

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,12 @@
 #!/usr/bin/env sh
 
 # developおよびmainブランチへの直接コミットを制限
-branch="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$branch" = "develop" ] || [ "$branch" = "main" ]; then
-  echo "Error: develop または main ブランチへの直接コミットは禁止されています。"
-  echo "機能の開発は feature/xxx 等のブランチで行い、プルリクエストを作成してください。"
-  exit 1
-fi
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|develop)
+    echo "Error: develop または main ブランチへの直接コミットは禁止されています。"
+    echo "機能の開発は feature/xxx 等のブランチで行い、プルリクエストを作成してください。"
+    exit 1
+    ;;
+esac
 
 yarn lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,11 @@
 #!/usr/bin/env sh
 
+# developおよびmainブランチへの直接コミットを制限
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" = "develop" ] || [ "$branch" = "main" ]; then
+  echo "Error: develop または main ブランチへの直接コミットは禁止されています。"
+  echo "機能の開発は feature/xxx 等のブランチで行い、プルリクエストを作成してください。"
+  exit 1
+fi
+
 yarn lint-staged


### PR DESCRIPTION
## 概要

<!-- このPRで何を行ったかを簡潔に記載 -->
develop, mainブランチへのコミットを制限する

## 関連Issue

<!-- closes #123 のように記載すると、マージ時にIssueが自動クローズされます -->
closes #60 

## 変更内容

<!-- 具体的な変更点をリストアップ -->
- pre-commit hookに現在のブランチ名を確認し、developまたはmainの時はexit 1とする処理を追加



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Gitのpre-commitフックが更新され、mainおよびdevelopブランチへの直接コミットを防止するようになりました。対象ブランチではコミットが中断され、その他のブランチでは既存のコード整形・検査処理が引き続き実行されます。これにより重要ブランチの保護が強化され、誤った直接コミットの防止が期待できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->