### PR TITLE
feat: proxy.tsを実装

### DIFF
--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -1,0 +1,37 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export function createClient(request: NextRequest) {
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            request.cookies.set(name, value),
+          );
+          response = NextResponse.next({
+            request: {
+              headers: request.headers,
+            },
+          });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  return { supabase, response };
+}

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -2,11 +2,13 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 export function createClient(request: NextRequest) {
-  let response = NextResponse.next({
-    request: {
-      headers: request.headers,
-    },
-  });
+  const res = {
+    response: NextResponse.next({
+      request: {
+        headers: request.headers,
+      },
+    }),
+  };
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -20,18 +22,18 @@ export function createClient(request: NextRequest) {
           cookiesToSet.forEach(({ name, value, options }) =>
             request.cookies.set(name, value),
           );
-          response = NextResponse.next({
+          res.response = NextResponse.next({
             request: {
               headers: request.headers,
             },
           });
           cookiesToSet.forEach(({ name, value, options }) =>
-            response.cookies.set(name, value, options),
+            res.response.cookies.set(name, value, options),
           );
         },
       },
     },
   );
 
-  return { supabase, response };
+  return { supabase, res };
 }

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -19,7 +19,7 @@ export function createClient(request: NextRequest) {
           return request.cookies.getAll();
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) =>
+          cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value),
           );
           res.response = NextResponse.next({

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,14 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/proxy";
 
+const PROTECTED_ROUTES = [
+  "/dashboard",
+  "/mypage",
+  "/calendar",
+  "/create_task",
+  "/task",
+];
+
 /**
  * Next.js v16 Proxy
  * リクエスト実行前に認証状態をチェックし、必要に応じてリダイレクトを行います。
@@ -14,23 +22,16 @@ export async function proxy(request: NextRequest) {
     const { data } = await supabase.auth.getUser();
     user = data.user;
   } catch (error) {
+    // 取得失敗時は安全側に倒し、user を null として扱う（保護ルートへのアクセスをブロック）
     console.error("getUser failed: ", error);
   }
 
-  const url = request.nextUrl.clone();
-  const { pathname } = url;
+  const { pathname } = request.nextUrl;
 
   // 保護されたルートの判定
-  const protectedRoutes = [
-    "/dashboard",
-    "/mypage",
-    "/calendar",
-    "/create_task",
-    "/task",
-  ];
   const matchesRoute = (route: string) =>
     pathname === route || pathname.startsWith(`${route}/`);
-  const isProtectedRoute = protectedRoutes.some(matchesRoute);
+  const isProtectedRoute = PROTECTED_ROUTES.some(matchesRoute);
 
   // 認証関連ページの判定
   const isAuthRoute = matchesRoute("/login");
@@ -54,9 +55,7 @@ export async function proxy(request: NextRequest) {
     );
     res.response.cookies
       .getAll()
-      .forEach((cookie) =>
-        redirectResponse.cookies.set(cookie.name, cookie.value),
-      );
+      .forEach((cookie) => redirectResponse.cookies.set(cookie));
 
     return redirectResponse;
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,7 @@ import { createClient } from "@/lib/supabase/proxy";
  * リクエスト実行前に認証状態をチェックし、必要に応じてリダイレクトを行います。
  */
 export async function proxy(request: NextRequest) {
-  const { supabase, response } = createClient(request);
+  const { supabase, res } = createClient(request);
 
   // 現在のユーザー情報を取得
   const {
@@ -33,7 +33,14 @@ export async function proxy(request: NextRequest) {
 
   // 未ログインで保護されたページにアクセスした場合、ログイン画面へリダイレクト
   if (!user && isProtectedRoute) {
-    return NextResponse.redirect(new URL("/login", request.url));
+    const redirectResponse = NextResponse.redirect(
+      new URL("/login", request.url),
+    );
+    res.response.cookies.getAll().forEach((cookie) => {
+      redirectResponse.cookies.set(cookie.name, cookie.value);
+    });
+
+    return redirectResponse;
   }
 
   // ログイン済みでログイン画面、またはトップ（スプラッシュ）にアクセスした場合、ダッシュボードへリダイレクト
@@ -41,7 +48,7 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
   }
 
-  return response;
+  return res.response;
 }
 
 export const config = {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,55 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/proxy";
+
+/**
+ * Next.js v16 Proxy
+ * リクエスト実行前に認証状態をチェックし、必要に応じてリダイレクトを行います。
+ */
+export async function proxy(request: NextRequest) {
+  const { supabase, response } = createClient(request);
+
+  // 現在のユーザー情報を取得
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const url = request.nextUrl.clone();
+  const { pathname } = url;
+
+  // 保護されたルートの判定
+  const isProtectedRoute =
+    pathname.startsWith("/dashboard") ||
+    pathname.startsWith("/mypage") ||
+    pathname.startsWith("/calendar") ||
+    pathname.startsWith("/create_task") ||
+    pathname.startsWith("/task");
+
+  // 認証関連ページの判定
+  const isAuthRoute = pathname.startsWith("/login");
+
+  // 未ログインで保護されたページにアクセスした場合、ログイン画面へリダイレクト
+  if (!user && isProtectedRoute) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  // ログイン済みでログイン画面、またはトップ（スプラッシュ）にアクセスした場合、ダッシュボードへリダイレクト
+  if (user && (isAuthRoute || pathname === "/")) {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * 次のパス以外のすべてのリクエストパスにマッチさせます：
+     * - api (APIルート)
+     * - _next/static (静的ファイル)
+     * - _next/image (画像最適化ファイル)
+     * - favicon.ico (ファビコン)
+     * - images (パブリック画像)
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico|images).*)",
+  ],
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,9 +9,13 @@ export async function proxy(request: NextRequest) {
   const { supabase, res } = createClient(request);
 
   // 現在のユーザー情報を取得
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  let user = null;
+  try {
+    const { data } = await supabase.auth.getUser();
+    user = data.user;
+  } catch (error) {
+    console.error("getUser failed: ", error);
+  }
 
   const url = request.nextUrl.clone();
   const { pathname } = url;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,12 +28,12 @@ export async function proxy(request: NextRequest) {
     "/create_task",
     "/task",
   ];
-  const isProtectedRoute = protectedRoutes.some((route) =>
-    pathname.startsWith(route),
-  );
+  const matchesRoute = (route: string) =>
+    pathname === route || pathname.startsWith(`${route}/`);
+  const isProtectedRoute = protectedRoutes.some(matchesRoute);
 
   // 認証関連ページの判定
-  const isAuthRoute = pathname.startsWith("/login");
+  const isAuthRoute = matchesRoute("/login");
 
   // 未ログインで保護されたページにアクセスした場合、ログイン画面へリダイレクト
   if (!user && isProtectedRoute) {
@@ -41,7 +41,7 @@ export async function proxy(request: NextRequest) {
       new URL("/login", request.url),
     );
     res.response.cookies.getAll().forEach((cookie) => {
-      redirectResponse.cookies.set(cookie.name, cookie.value);
+      redirectResponse.cookies.set(cookie);
     });
 
     return redirectResponse;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -45,7 +45,16 @@ export async function proxy(request: NextRequest) {
 
   // ログイン済みでログイン画面、またはトップ（スプラッシュ）にアクセスした場合、ダッシュボードへリダイレクト
   if (user && (isAuthRoute || pathname === "/")) {
-    return NextResponse.redirect(new URL("/dashboard", request.url));
+    const redirectResponse = NextResponse.redirect(
+      new URL("/dashboard", request.url),
+    );
+    res.response.cookies
+      .getAll()
+      .forEach((cookie) =>
+        redirectResponse.cookies.set(cookie.name, cookie.value),
+      );
+
+    return redirectResponse;
   }
 
   return res.response;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,12 +17,16 @@ export async function proxy(request: NextRequest) {
   const { pathname } = url;
 
   // 保護されたルートの判定
-  const isProtectedRoute =
-    pathname.startsWith("/dashboard") ||
-    pathname.startsWith("/mypage") ||
-    pathname.startsWith("/calendar") ||
-    pathname.startsWith("/create_task") ||
-    pathname.startsWith("/task");
+  const protectedRoutes = [
+    "/dashboard",
+    "/mypage",
+    "/calendar",
+    "/create_task",
+    "/task",
+  ];
+  const isProtectedRoute = protectedRoutes.some((route) =>
+    pathname.startsWith(route),
+  );
 
   // 認証関連ページの判定
   const isAuthRoute = pathname.startsWith("/login");

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -70,6 +70,6 @@ export const config = {
      * - favicon.ico (ファビコン)
      * - images (パブリック画像)
      */
-    "/((?!api|_next/static|_next/image|favicon.ico|images).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|images|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|json|woff2?|ttf|eot)$).*)",
   ],
 };


### PR DESCRIPTION
## 概要

<!-- このPRで何を行ったかを簡潔に記載 -->
proxy.tsを実装し、認証済みでない時はlogin画面にリダイレクト。認証が必要な画面には遷移できないようにする。

## 関連Issue

<!-- closes #123 のように記載すると、マージ時にIssueが自動クローズされます -->
closes #81 


## チェックリスト

- [ ] コードがプロジェクトのスタイルガイドに従っている
- [ ] セルフレビューを行った
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がないことを確認した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 認証に基づくアクセス制御をミドルウェアで強化しました。保護されたページは未認証時にログインへ、自動ログイン済みユーザーはダッシュボードへリダイレクトされます。
* **改良**
  * セッション／クッキー同期を改善し、リダイレクト時や通常遷移時に認証状態が正しく維持されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->