### PR TITLE
refactor: カレンダーページのコンポーネント分割

### DIFF
--- a/src/app/calendar/CalendarHeader.tsx
+++ b/src/app/calendar/CalendarHeader.tsx
@@ -1,0 +1,16 @@
+/**
+ * カレンダーページのヘッダーコンポーネント
+ * タイトルと説明文を表示します。
+ */
+const CalendarHeader = () => {
+  return (
+    <div className="mb-10 text-center md:text-left bg-white/40 dark:bg-zinc-800/10 p-6 rounded-3xl backdrop-blur-md border border-white/20 dark:border-zinc-700/30">
+      <h2 className="text-xl font-bold tracking-tight mb-2">履歴カレンダー</h2>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400">
+        メンテナンスタスクの完了履歴を振り返りましょう。
+      </p>
+    </div>
+  );
+};
+
+export default CalendarHeader;

--- a/src/app/calendar/LogItem.tsx
+++ b/src/app/calendar/LogItem.tsx
@@ -1,0 +1,47 @@
+import { format } from "date-fns";
+import { MaintenanceItem } from "@/types/maintenance";
+import { MaintenanceLog } from "@/types/maintenance";
+
+type Props = {
+  /** 表示するログデータ */
+  log: MaintenanceLog;
+  /** ログに対応するメンテナンス項目（削除済みの場合は undefined） */
+  item: MaintenanceItem | undefined;
+};
+
+/**
+ * ログ1件分の行コンポーネント
+ * アイコン・タスク名・完了時刻を表示します。
+ */
+const LogItem = ({ log, item }: Props) => {
+  return (
+    <div className="p-4 flex items-center gap-4 hover:bg-zinc-50 dark:hover:bg-zinc-700/50 transition-colors group">
+      <div className="w-12 h-12 rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-600 dark:text-emerald-400 flex items-center justify-center shrink-0 text-xl shadow-inner group-hover:scale-105 transition-transform">
+        {item?.icon || "✅"}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="font-semibold text-zinc-800 dark:text-zinc-200 truncate">
+          {item?.name || "削除されたタスク"}
+        </p>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1 flex items-center gap-1">
+          <svg
+            className="w-3 h-3"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          {format(new Date(log.completed_at), "HH:mm")}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default LogItem;

--- a/src/app/calendar/LogItem.tsx
+++ b/src/app/calendar/LogItem.tsx
@@ -25,6 +25,8 @@ const LogItem = ({ log, item }: Props) => {
         <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1 flex items-center gap-1">
           <svg
             className="w-3 h-3"
+            aria-hidden="true"
+            focusable="false"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"

--- a/src/app/calendar/LogItem.tsx
+++ b/src/app/calendar/LogItem.tsx
@@ -1,6 +1,5 @@
 import { format } from "date-fns";
-import { MaintenanceItem } from "@/types/maintenance";
-import { MaintenanceLog } from "@/types/maintenance";
+import { MaintenanceItem, MaintenanceLog } from "@/types/maintenance";
 
 type Props = {
   /** 表示するログデータ */

--- a/src/app/calendar/LogList.tsx
+++ b/src/app/calendar/LogList.tsx
@@ -59,6 +59,8 @@ const LogList = ({
           <p className="text-red-600 dark:text-red-400 font-semibold mb-1 flex items-center justify-center gap-2">
             <svg
               className="w-5 h-5"
+              aria-hidden="true"
+              focusable="false"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"

--- a/src/app/calendar/LogList.tsx
+++ b/src/app/calendar/LogList.tsx
@@ -1,0 +1,98 @@
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import { MaintenanceItem, MaintenanceLog } from "@/types/maintenance";
+import LogItem from "./LogItem";
+
+type Props = {
+  /** 選択中の日付 */
+  selectedDate: Date;
+  /** 選択日のログ一覧 */
+  selectedLogs: MaintenanceLog[];
+  /** ログ検索用のアイテムマップ（id -> MaintenanceItem） */
+  itemMap: Map<string, MaintenanceItem>;
+  /** ログデータのローディング状態 */
+  isLogsLoading: boolean;
+  /** アイテムデータのローディング状態 */
+  isItemsLoading: boolean;
+  /** ログデータのエラー状態 */
+  isLogsError: boolean;
+  /** アイテムデータのエラー状態 */
+  isItemsError: boolean;
+  /** ログデータのエラーオブジェクト */
+  logsError: Error | null;
+  /** アイテムデータのエラーオブジェクト */
+  itemsError: Error | null;
+};
+
+/**
+ * 選択日のログ一覧パネルコンポーネント
+ * ローディング・エラー・空状態・ログ一覧の各状態を表示します。
+ */
+const LogList = ({
+  selectedDate,
+  selectedLogs,
+  itemMap,
+  isLogsLoading,
+  isItemsLoading,
+  isLogsError,
+  isItemsError,
+  logsError,
+  itemsError,
+}: Props) => {
+  return (
+    <div
+      className="w-full lg:w-[40%] animate-fade-in-up flex flex-col gap-4"
+      style={{ animationDelay: "100ms" }}
+    >
+      <h3 className="text-lg font-bold text-zinc-800 dark:text-zinc-200 pl-1 border-b border-zinc-200 dark:border-zinc-700 pb-2">
+        {format(selectedDate, "M月d日 (E)", { locale: ja })} の履歴
+      </h3>
+
+      {/* ローディング中 */}
+      {isLogsLoading || isItemsLoading ? (
+        <div className="flex justify-center items-center py-12">
+          <div className="animate-spin h-8 w-8 border-4 border-indigo-500 rounded-full border-t-transparent"></div>
+        </div>
+      ) : isLogsError || isItemsError ? (
+        /* エラー時 */
+        <div className="bg-red-50 dark:bg-red-900/10 rounded-2xl p-6 text-center border border-red-100 dark:border-red-800/30">
+          <p className="text-red-600 dark:text-red-400 font-semibold mb-1 flex items-center justify-center gap-2">
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            データの取得に失敗しました
+          </p>
+          <p className="text-sm text-red-500/80 dark:text-red-400/80 mt-2">
+            {logsError?.message ||
+              itemsError?.message ||
+              "ページを再読み込みしてお試しください。"}
+          </p>
+        </div>
+      ) : selectedLogs.length > 0 ? (
+        /* ログ一覧 */
+        <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow-sm border border-zinc-100 dark:border-zinc-700 divide-y divide-zinc-100 dark:divide-zinc-700 overflow-hidden">
+          {selectedLogs.map((log) => (
+            <LogItem key={log.id} log={log} item={itemMap.get(log.item_id)} />
+          ))}
+        </div>
+      ) : (
+        /* 空状態 */
+        <div className="bg-white/60 dark:bg-zinc-800/40 rounded-2xl p-8 text-center text-zinc-500 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700">
+          <p>この日の履歴はありません。</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LogList;

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -3,10 +3,11 @@
 import { useState, useMemo } from "react";
 import Calendar from "@/components/Calendar";
 import Header from "@/components/Header";
-import { startOfMonth, endOfMonth, isSameDay, format } from "date-fns";
-import { ja } from "date-fns/locale";
+import { startOfMonth, endOfMonth, isSameDay } from "date-fns";
 import { useMaintenanceLogs } from "@/hooks/useMaintenanceLogs";
 import useMaintenanceItems from "@/hooks/useMaintenanceItems";
+import CalendarHeader from "./CalendarHeader";
+import LogList from "./LogList";
 
 export default function CalendarPage() {
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -26,12 +27,6 @@ export default function CalendarPage() {
     () => fetchMaintenanceItems.data || [],
     [fetchMaintenanceItems.data],
   );
-  const isItemsError = fetchMaintenanceItems.isError;
-  const itemsError = fetchMaintenanceItems.error;
-
-  const handleDayClick = (date: Date) => {
-    setSelectedDate(date);
-  };
 
   const selectedLogs = logs.filter((log) =>
     isSameDay(new Date(log.completed_at), selectedDate),
@@ -46,104 +41,29 @@ export default function CalendarPage() {
     <div className="min-h-screen bg-lavender p-6 dark:bg-zinc-900 font-sans text-zinc-900 dark:text-zinc-100">
       <Header />
       <main className="max-w-5xl mx-auto pb-20">
-        <div className="mb-10 text-center md:text-left bg-white/40 dark:bg-zinc-800/10 p-6 rounded-3xl backdrop-blur-md border border-white/20 dark:border-zinc-700/30">
-          <h2 className="text-xl font-bold tracking-tight mb-2">
-            履歴カレンダー
-          </h2>
-          <p className="text-sm text-zinc-500 dark:text-zinc-400">
-            メンテナンスタスクの完了履歴を振り返りましょう。
-          </p>
-        </div>
+        <CalendarHeader />
 
         <div className="flex flex-col lg:flex-row gap-8">
           <div className="w-full lg:w-[60%] shrink-0 animate-fade-in-up">
             <Calendar
               logs={logs}
-              onDayClick={handleDayClick}
+              onDayClick={setSelectedDate}
               currentDate={currentDate}
               setCurrentDate={setCurrentDate}
             />
           </div>
 
-          <div
-            className="w-full lg:w-[40%] animate-fade-in-up flex flex-col gap-4"
-            style={{ animationDelay: "100ms" }}
-          >
-            <h3 className="text-lg font-bold text-zinc-800 dark:text-zinc-200 pl-1 border-b border-zinc-200 dark:border-zinc-700 pb-2">
-              {format(selectedDate, "M月d日 (E)", { locale: ja })} の履歴
-            </h3>
-
-            {isLogsLoading || fetchMaintenanceItems.isLoading ? (
-              <div className="flex justify-center items-center py-12">
-                <div className="animate-spin h-8 w-8 border-4 border-indigo-500 rounded-full border-t-transparent"></div>
-              </div>
-            ) : isLogsError || isItemsError ? (
-              <div className="bg-red-50 dark:bg-red-900/10 rounded-2xl p-6 text-center border border-red-100 dark:border-red-800/30">
-                <p className="text-red-600 dark:text-red-400 font-semibold mb-1 flex items-center justify-center gap-2">
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  データの取得に失敗しました
-                </p>
-                <p className="text-sm text-red-500/80 dark:text-red-400/80 mt-2">
-                  {(logsError as Error)?.message ||
-                    (itemsError as Error)?.message ||
-                    "ページを再読み込みしてお試しください。"}
-                </p>
-              </div>
-            ) : selectedLogs.length > 0 ? (
-              <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow-sm border border-zinc-100 dark:border-zinc-700 divide-y divide-zinc-100 dark:divide-zinc-700 overflow-hidden">
-                {selectedLogs.map((log) => {
-                  const item = itemMap.get(log.item_id);
-                  return (
-                    <div
-                      key={log.id}
-                      className="p-4 flex items-center gap-4 hover:bg-zinc-50 dark:hover:bg-zinc-700/50 transition-colors group"
-                    >
-                      <div className="w-12 h-12 rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-600 dark:text-emerald-400 flex items-center justify-center shrink-0 text-xl shadow-inner group-hover:scale-105 transition-transform">
-                        {item?.icon || "✅"}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-semibold text-zinc-800 dark:text-zinc-200 truncate">
-                          {item?.name || "削除されたタスク"}
-                        </p>
-                        <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1 flex items-center gap-1">
-                          <svg
-                            className="w-3 h-3"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                            />
-                          </svg>
-                          {format(new Date(log.completed_at), "HH:mm")}
-                        </p>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="bg-white/60 dark:bg-zinc-800/40 rounded-2xl p-8 text-center text-zinc-500 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700">
-                <p>この日の履歴はありません。</p>
-              </div>
-            )}
-          </div>
+          <LogList
+            selectedDate={selectedDate}
+            selectedLogs={selectedLogs}
+            itemMap={itemMap}
+            isLogsLoading={isLogsLoading}
+            isItemsLoading={fetchMaintenanceItems.isLoading}
+            isLogsError={isLogsError}
+            isItemsError={fetchMaintenanceItems.isError}
+            logsError={logsError as Error | null}
+            itemsError={fetchMaintenanceItems.error as Error | null}
+          />
         </div>
       </main>
     </div>

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -61,8 +61,8 @@ export default function CalendarPage() {
             isItemsLoading={fetchMaintenanceItems.isLoading}
             isLogsError={isLogsError}
             isItemsError={fetchMaintenanceItems.isError}
-            logsError={logsError as Error | null}
-            itemsError={fetchMaintenanceItems.error as Error | null}
+            logsError={logsError}
+            itemsError={fetchMaintenanceItems.error}
           />
         </div>
       </main>

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -44,7 +44,7 @@ export default function CalendarPage() {
         <CalendarHeader />
 
         <div className="flex flex-col lg:flex-row gap-8">
-          <div className="w-full lg:w-[60%] shrink-0 animate-fade-in-up">
+          <div className="w-full lg:w-[60%] shrink-0">
             <Calendar
               logs={logs}
               onDayClick={setSelectedDate}

--- a/src/app/create_task/CreateTaskHeader.tsx
+++ b/src/app/create_task/CreateTaskHeader.tsx
@@ -12,6 +12,7 @@ const CreateTaskHeader = () => {
   return (
     <header className="mb-12 flex items-center justify-between mt-8">
       <button
+        type="button"
         onClick={() => router.back()}
         className="flex items-center gap-2 text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors group cursor-pointer"
       >

--- a/src/app/create_task/CreateTaskHeader.tsx
+++ b/src/app/create_task/CreateTaskHeader.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+/**
+ * タスク新規登録ページのヘッダーコンポーネント
+ * 「戻る」ボタンとページタイトルを表示します。
+ */
+const CreateTaskHeader = () => {
+  const router = useRouter();
+
+  return (
+    <header className="mb-12 flex items-center justify-between mt-8">
+      <button
+        onClick={() => router.back()}
+        className="flex items-center gap-2 text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors group cursor-pointer"
+      >
+        <span className="text-xl group-hover:-translate-x-1 transition-transform">
+          ←
+        </span>
+        <span className="font-medium">戻る</span>
+      </button>
+      <h1 className="text-2xl font-bold tracking-tight">タスクの新規登録</h1>
+      <div className="w-16" /> {/* バランス用スペーサー */}
+    </header>
+  );
+};
+
+export default CreateTaskHeader;

--- a/src/app/create_task/page.tsx
+++ b/src/app/create_task/page.tsx
@@ -5,6 +5,7 @@ import { parseISO, startOfDay } from "date-fns";
 import { toast } from "react-toastify";
 import useMaintenanceItems from "@/hooks/useMaintenanceItems";
 import TaskForm, { TaskFormValues } from "@/components/TaskForm";
+import CreateTaskHeader from "./CreateTaskHeader";
 
 export default function CreateTaskPage() {
   const router = useRouter();
@@ -41,22 +42,7 @@ export default function CreateTaskPage() {
   return (
     <div className="min-h-screen bg-zinc-50 p-6 dark:bg-zinc-900 font-sans text-zinc-900 dark:text-zinc-100 flex flex-col items-center">
       <div className="max-w-2xl w-full">
-        {/* ヘッダーセクション */}
-        <header className="mb-12 flex items-center justify-between mt-8">
-          <button
-            onClick={() => router.back()}
-            className="flex items-center gap-2 text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors group cursor-pointer"
-          >
-            <span className="text-xl group-hover:-translate-x-1 transition-transform">
-              ←
-            </span>
-            <span className="font-medium">戻る</span>
-          </button>
-          <h1 className="text-2xl font-bold tracking-tight">
-            タスクの新規登録
-          </h1>
-          <div className="w-16" /> {/* バランス用スペーサー */}
-        </header>
+        <CreateTaskHeader />
 
         {/* フォームカード */}
         <main


### PR DESCRIPTION
## 概要

<!-- このPRで何を行ったかを簡潔に記載 -->
カレンダーページのコンポーネントを分割

## 関連Issue

<!-- closes #123 のように記載すると、マージ時にIssueが自動クローズされます -->
closes #83 

## 変更内容

<!-- 具体的な変更点をリストアップ -->
- page.tsxはデータ取得と状態管理だけを行う
- ヘッダーコンポーネントの分割
- ログ一覧パネルを分割




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * カレンダーページのUI構造を複数の専用コンポーネントに分離
  * タスク作成ページのヘッダーを独立したコンポーネントに抽出
  * メンテナンスログの表示機能をコンポーネント化して整理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->